### PR TITLE
Make authentication optional

### DIFF
--- a/src/grafana.js
+++ b/src/grafana.js
@@ -29,8 +29,12 @@ var body = {};
 
 function Grafana(conf, comps) {
 	grafana_url = conf.grafana.url;
-	auth.username = conf.grafana.username;
-	auth.password = conf.grafana.password;
+	if (conf.grafana.username && conf.grafana.password) {
+		auth.username = conf.grafana.username;
+		auth.password = conf.grafana.password;
+	} else {
+		auth = null;
+	}
 	if (conf.grafana.debug_api === true || conf.grafana.debug_api === 'true') {
 		request.debug = true;
 	} else {
@@ -492,7 +496,9 @@ Grafana.prototype.clip = function(commands) {
 			'?width=' + config.clip.render_width + '&height=' + config.clip.render_height + '&timeout=' +
 			config.clip.render_timeout;
 
-		url = addAuth(url);
+		if (auth) {
+			url = addAuth(url);
+		}
 
 		var now = (new Date).getTime();
 


### PR DESCRIPTION
Some Grafana instances don't use authentication, so let's not pass it if
none is given.