### PR TITLE
add support for using bearer token with import/export dashboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "request": "^2.83.0",
     "aws-sdk": "^2.133.0",
     "png-file-stream": "^1.0.0",
-    "sync-request": "^4.0.1"
+    "sync-request": "^4.1.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This PR adds support for using a bearer token when bulk importing and exporting dashboards, which would previously result in a silent failure.

It also adds error handling to report when the server returns a non-200 response code, and updates the dashboards import/export functions to have the same basic structure, and fixes a couple more whitespace issues.  I updated the sync-request requirement to the latest release also.